### PR TITLE
Update docs to 'legacy' isntead of 'deprecated'

### DIFF
--- a/docs/content/docs/delay-withdraws.mdx
+++ b/docs/content/docs/delay-withdraws.mdx
@@ -1,6 +1,6 @@
 ---
 title: Delayed Withdraws
-description: Deprecated in favor of BoringQueue.
+description: Legacy. Replaced with BoringQueue.
 ---
 
 ## Introduction

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -15,7 +15,7 @@
     "boring-queue",
     "merkle-distributions",
     "boring-queue-ui-integration",
-    "---Deprecated---",
+    "---Legacy---",
     "withdraw-queue",
     "delay-withdraws"
   ]

--- a/docs/content/docs/withdraw-queue.mdx
+++ b/docs/content/docs/withdraw-queue.mdx
@@ -1,6 +1,6 @@
 ---
 title: Withdraw Queue
-description: Deprecated in favor of BoringQueue.
+description: Legacy. Replaced with BoringQueue.
 ---
 
 ## Introduction


### PR DESCRIPTION
This pull request updates documentation to replace the term "Deprecated" with "Legacy" for better clarity and consistency. The most important changes include updates to the descriptions and metadata in relevant documentation files.

### Documentation updates:

* [`docs/content/docs/delay-withdraws.mdx`](diffhunk://#diff-49a96b43e62fe910271b35fe9f762c48248ffc8054db3c0d72990168b68a6283L3-R3): Updated the description to replace "Deprecated in favor of BoringQueue" with "Legacy. Replaced with BoringQueue."
* [`docs/content/docs/withdraw-queue.mdx`](diffhunk://#diff-f6c63aea535c6f73882a485b79e165f540834dcbdea223d45a4b2d28d76dd1afL3-R3): Updated the description to replace "Deprecated in favor of BoringQueue" with "Legacy. Replaced with BoringQueue."
* [`docs/content/docs/meta.json`](diffhunk://#diff-e0878d2923352c88a06ea192a12c1557fe10238ad4423c18bd6c08b0685a8273L18-R18): Changed the label "---Deprecated---" to "---Legacy---" in the metadata array.